### PR TITLE
Add support for config file, .umm.json

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,11 @@
+const path = require('path');
+const fs = require('fs');
+
+const configFilePath = path.join(process.cwd(), '.umm.json');
+
+if (fs.existsSync(configFilePath)) {
+  const data = fs.readFileSync(configFilePath);
+  module.exports = JSON.parse(data);
+} else {
+  module.exports = {};
+}

--- a/src/generate_assembly_definition.js
+++ b/src/generate_assembly_definition.js
@@ -7,6 +7,7 @@ module.exports = () => {
     console.error('`package.json` does not found.');
     process.exit(1);
   }
+  const config = require('../lib/config');
   const info = require('../lib/info');
   const package = require(path.join(path.resolve('./'), 'package.json'));
 
@@ -31,6 +32,13 @@ module.exports = () => {
   })
   .map(key => {
     return key.replace(/^(@)?([^\/]+)?(\/)?([^\/]+)$/, "$2$1$4");
+  });
+
+  Array.prototype.push.apply(assemblyDefinition.references, config.automatic_reference_assmblies);
+  assemblyDefinition.references.sort((a, b) => {
+    a = a.toString().toLowerCase();
+    b = b.toString().toLowerCase();
+    return (a > b) ? 1 : (b > a) ? -1 : 0;
   });
 
   fs.writeFileSync(


### PR DESCRIPTION
以前話していたように `.umm.json` を project の root においておき、以下のような記述をすると、`automatic_reference_assmblies` の内容が AssemblyDefinition に追加されるようにしました。

```
{
  "automatic_reference_assmblies": [
    "Unity.TextMeshPro"
  ]
}
```